### PR TITLE
Perform install and package moves in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM node:16
 
 WORKDIR /app
 COPY . .
-RUN npm install && npm run build && cp -a build/* /app/public
+RUN npm run build
 CMD ["npm", "run", "start-sv"]

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ app.get("/getrewards", async (req, res) => {
     }
 });
 
-app.use(express.static('public'))
+app.use(express.static('serve'))
 
 app.listen(PORT, () => {
     console.log(`Server listening on ${PORT}`);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "clean": "rm -rf serve/*",
+    "build": "npm install && react-scripts build && cp -a build/* serve",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "start-sv": "node --inspect index.js"


### PR DESCRIPTION
Move the `npm install` and `cp` to `serve` to the package.json `build`
target, so we can simplify installation.

Simply `npm run build` to build and copy the React app to `serve`.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>