### PR TITLE
Allow setting DOCKER_USERS in .env

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -60,6 +60,7 @@ pip install ansible==5.1.0 docker requests
 ansible-galaxy install -r ${__repo}/ansible/requirements.yml
 ansible-playbook ${__repo}/ansible/local.yml \
 	-e REPO=${__repo} \
+	-e DOCKER_USERS=${DOCKER_USERS:-ubuntu} \
 	-e vm_frontend_port=${PORT:-3000} \
 	-e ansible_python_interpreter=${__repo}/.venv/bin/python3 \
 	--diff \


### PR DESCRIPTION
This is especially useful for anyone not running on a Ubuntu cloud
instance.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>