### PR TITLE
Add Redis container

### DIFF
--- a/ansible/roles/vm_frontend/defaults/main.yml
+++ b/ansible/roles/vm_frontend/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+redis_enabled: true
 vm_frontend_version: 'master'
 vm_frontend_image: 'ghcr.io/tosidrop/vm-frontend:{{ vm_frontend_version }}'
 vm_frontend_port: 3000

--- a/ansible/roles/vm_frontend/tasks/main.yml
+++ b/ansible/roles/vm_frontend/tasks/main.yml
@@ -1,9 +1,23 @@
 ---
+- name: Create Redis cache container
+  docker_container:
+    name: redis
+    image: redis
+    ports:
+      - 6379:6379
+    pull: false # false to prevent cache loss
+    read_only: true
+    restart_policy: unless-stopped
+    state: started
+  when: redis_enabled
+
 - name: Create VM frontend container
   docker_container:
     name: vm-frontend
     env:
       PORT: '{{ vm_frontend_port | string }}'
+      REDIS_ENABLED: '{{ redis_enabled | string }}'
+      REDIS_HOST: '172.17.0.1'
     image: '{{ vm_frontend_image }}'
     ports:
       - '{{ vm_frontend_port }}:{{ vm_frontend_port }}'

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,8 @@ require('dotenv').config()
 
 const CLOUDFLARE_PSK = process.env.CLOUDFLARE_PSK;
 const PORT = process.env.PORT || 3000;
+const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
+const REDIS_PORT = process.env.REDIS_PORT || 6379;
 const VM_API_TOKEN = process.env.VM_API_TOKEN_TESTNET || process.env.VM_API_TOKEN;
 const VM_URL = process.env.VM_URL_TESTNET || process.env.VM_URL;
 const VM_KOIOS_URL = process.env.KOIOS_URL_TESTNET || process.env.KOIOS_URL;


### PR DESCRIPTION
Configure a Redis container on the default port and inject connection
constants into the Express server to be used for entity caching.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>