### PR TITLE
Support MANAGE_DOCKER in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ for the frontend, and a React UI which is built into static assets.
 This is intended for use via Docker.
 
 Within this repository is an Ansible playbook to install Docker on the local
-machine and run the containers.
+machine and run the containers. You can disable installing Docker by setting
+`MANAGE_DOCKER=false` in `.env`.
 
 ## Usage
 

--- a/ansible/local.yml
+++ b/ansible/local.yml
@@ -24,6 +24,7 @@
           log-driver: "local"
       tags:
         - always
+      when: "{{ MANAGE_DOCKER | default('true') }} == 'true'"
 
     - name: nodePlaybook | include vm_frontend role
       include_role:

--- a/runme.sh
+++ b/runme.sh
@@ -65,6 +65,7 @@ ansible-galaxy install -r ${__repo}/ansible/requirements.yml
 ansible-playbook ${__repo}/ansible/local.yml \
 	-e REPO=${__repo} \
 	-e DOCKER_USERS=${DOCKER_USERS:-ubuntu} \
+	-e MANAGE_DOCKER=${MANAGE_DOCKER:-true} \
 	-e vm_frontend_port=${PORT:-3000} \
 	-e ansible_python_interpreter=${__repo}/.venv/bin/python3 \
 	--diff \


### PR DESCRIPTION
Add support for MANAGE_DOCKER in the .env file to allow someone to
diable the management of the Docker daemon, such as if they've already
provided it on the host via other means.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>