### PR TITLE
Add static /network endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 
 RUN npm run build
 RUN npm run build-client
-CMD ["npm", "run", "start"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+__app=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)
+
+# Write out our network configuration
+mkdir -p ${__app}/client/build && echo ${CARDANO_NETWORK:-testnet} > ${__app}/client/build/network
+
+# Check for arguments
+# No arguments passed or first argument begins with dash
+if [[ ${#} -eq 0 ]] || [[ ${1#-} != ${1} ]]; then
+	set -- npm run start "${@}"
+fi
+
+exec "${@}"


### PR DESCRIPTION
Create a docker-entrypoint.sh script to automatically generate a static
network file so Express will serve it on /network. This will likely be
moved into Express in the near future.

```
$ curl -s http://localhost:3000/network
testnet
```


Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>