### PR TITLE
Add /network endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 
 RUN npm run build
 RUN npm run build-client
-CMD ["npm", "run", "start"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+__app=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)
+
+# Check for arguments
+# No arguments passed or first argument begins with dash
+if [[ ${#} -eq 0 ]] || [[ ${1#-} != ${1} ]]; then
+	set -- npm run start "${@}"
+fi
+
+exec "${@}"

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import { ExtendedMetadata, Metadata } from './client/src/entities/common.entitie
 import { formatTokens } from './client/src/services/utils.services'
 require('dotenv').config()
 
+const CARDANO_NETWORK = process.env.CARDANO_NETWORK || 'testnet';
 const CLOUDFLARE_PSK = process.env.CLOUDFLARE_PSK;
 const PORT = process.env.PORT || 3000;
 const REDIS_HOST = process.env.REDIS_HOST || 'localhost';
@@ -95,6 +96,12 @@ app.get("/healthz", async (req: any, res: any) => {
             status: "UP"
         })
     }
+});
+
+app.get("/network", (req: any, res: any) => {
+    res.status(200).json({
+        network: CARDANO_NETWORK
+    })
 });
 
 app.get("/sanitizeaddr", async (req: any, res: any) => {


### PR DESCRIPTION
Create a static /network endpoint and introduce a simple entrypoint
script to allow for easier modifications of the runtime within the
container image.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>