### PR TITLE
Use multistage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM node:16 AS base
-WORKDIR /app
 
 FROM base AS builder
+WORKDIR /code
 COPY . .
-
 RUN npm run build
 RUN npm run build-client
+
+FROM base AS final
+WORKDIR /app
+COPY --from=builder --chmod=555 /code/docker-entrypoint.sh .
+COPY --from=builder /code/index.ts /code/package.json /code/tsconfig.json ./
+COPY --from=builder /code/node_modules ./node_modules/
+COPY --from=builder /code/client/src/entities/ ./client/src/entities/
+COPY --from=builder /code/client/src/services/ ./client/src/services/
+COPY --from=builder /code/client/build/ ./client/build/
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/runme.sh
+++ b/runme.sh
@@ -31,7 +31,8 @@ else
 		KOIOS_URL=https://koios.rest/api/v0
 		VM_URL=https://vm.adaseal.eu
 	fi
-	echo "KOIOS_URL=${KOIOS_URL}" > ${__repo}/.env
+	echo "CARDANO_NETWORK=${CARDANO_NETWORK}" > ${__repo}/.env
+	echo "KOIOS_URL=${KOIOS_URL}" >> ${__repo}/.env
 	echo "VM_URL=${VM_URL}" >> ${__repo}/.env
 	echo "VM_API_TOKEN=${VM_API_TOKEN}" >> ${__repo}/.env
 	if test -n "${CLOUDFLARE_PSK}"; then


### PR DESCRIPTION
Use a multistage Dockerfile and reduce the container disk footprint.

```
$ docker images | grep tosi
tosidrop/vm-frontend                                                 latest     e70810a79541   32 minutes ago      1.01GB
tosidrop/vm-frontend                                                 orig       f686fec20376   11 minutes ago      1.63GB
```

This shaves about 630MiB from the final image. :muscle:

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>