### PR TITLE
GH-58 Fallback route to React

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ const VM_KOIOS_URL = process.env.KOIOS_URL_TESTNET || process.env.KOIOS_URL;
 
 const app = express();
 app.use(cors());
+// Serve our React app
 app.use(express.static('client/build'));
 app.use(express.json());
 
@@ -329,3 +330,8 @@ async function getRewards(stakeAddress: string) {
     }
     return getRewardsResponse;
 }
+
+// Fallback to React app
+app.get('*', (req, res) => {
+    res.sendFile('client/build/index.html', { root: __dirname });
+});


### PR DESCRIPTION
If a path doesn't match an explicit Express route, we should send it to
React to let it handle it with browser-side routing.

Fixes #58

![image](https://user-images.githubusercontent.com/380021/164472954-34d5705a-337a-4742-9586-8a9b000b0b16.png)


Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>