### PR TITLE
Wallet: use name property instead of key

### DIFF
--- a/client/src/components/wallet-selector/wallet-selector-modal/wallet-selector-modal.component.tsx
+++ b/client/src/components/wallet-selector/wallet-selector-modal/wallet-selector-modal.component.tsx
@@ -63,8 +63,7 @@ function WalletSelectorModalComponent({
                                             }
                                         >
                                             <p>
-                                                {key.charAt(0).toUpperCase() +
-                                                    key.slice(1)}
+                                                {window.cardano[key].name}
                                             </p>
                                             <img
                                                 src={window.cardano[key].icon}


### PR DESCRIPTION
Some key names do not reflect the name of the wallet, use name property instead.