### PR TITLE
fix/server: set unlock/fee for non-wl pools

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -226,7 +226,9 @@ app.get("/getcustomrewards", async (req: any, res: any) => {
         const accountInfo = accountsInfo[0];
         if (whitelist.includes(accountInfo.delegated_pool)) {
           vmArgs += "&unlocks_special=true";
-        }
+	} else {
+          vmArgs += `&overhead_fee=${TOSIFEE}&unlocks_special=true`;
+	}
       } else {
         vmArgs += `&overhead_fee=${TOSIFEE}&unlocks_special=true`;
       }


### PR DESCRIPTION
When a TOSIFEE_WHITELIST is defined and a user does not match the
whitelisted pools, set TOSIFEE and unlock project locked tokens.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>