### PR TITLE
fix: use same name for getdeliveredrewards param

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -573,9 +573,9 @@ app.get(
   async (req: any, res: any) => {
     try {
       const queryObject = url.parse(req.url, true).query;
-      const stakeAddress = queryObject.staking_address as string;
-      let vmArgs = `delivered_rewards&staking_address=${stakeAddress}`;
-      if (!stakeAddress)
+      const { staking_address } = queryObject;
+      let vmArgs = `delivered_rewards&staking_address=${staking_address}`;
+      if (!staking_address)
         return res
           .status(400)
           .send({ error: "No address provided to /api/getdeliveredrewards" });


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>