### PR TITLE
Revert "ci: fix multi-arch-manifest workaround"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,15 +71,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      # TEMP fix
-      # Something strange is happening with the manifests when we push which
-      # breaks the downstream multi-arch-manifest, so pull and push to work
-      # around this by resubmitting manifests
-      - name: pull-and-push
-        run: |
-          for t in `echo '${{ steps.meta.outputs.tags }}'`; do
-            docker pull $t && docker push $t
-          done
 
   build-arm64:
     runs-on: self-hosted
@@ -140,15 +131,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      # TEMP fix
-      # Something strange is happening with the manifests when we push which
-      # breaks the downstream multi-arch-manifest, so pull and push to work
-      # around this by resubmitting manifests
-      - name: pull-and-push
-        run: |
-          for t in `echo '${{ steps.meta.outputs.tags }}'`; do
-            docker pull $t && docker push $t
-          done
 
   multi-arch-manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 308ae005b320064c47e258ba5970efacce2ae45d.