### PR TITLE
ci: allow publish workflow for forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ concurrency: ${{ github.ref }}
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: tosidrop/vm-frontend
+  IMAGE_NAME: ${{ github.repository == 'TosiDrop/vm-frontend' && 'tosidrop/vm-frontend' || github.repository }}
 
 jobs:
   build-amd64:


### PR DESCRIPTION
This will allow me to publish images for the downstream blinklabs-io/tosidrop-vm-frontend fork via CI