### PR TITLE
ci(docker): skip self-hosted runners

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -10,7 +10,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-amd64:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,54 +18,16 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - id: buildx
         uses: docker/setup-buildx-action@v3
-      - uses: actions/cache@v4
+      - id: meta
+        uses: docker/metadata-action@v5
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-buildx-
+          images: ${{ env.GHCR_IMAGE_NAME }}
       - name: build
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
-          tags: tosidrop:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      # TEMP fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  build-arm64:
-    runs-on: ["self-hosted", "ARM64"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: qemu
-        uses: docker/setup-qemu-action@v3
-      - id: buildx
-        uses: docker/setup-buildx-action@v3
-      - uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-buildx-
-      - name: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          tags: tosidrop:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      # TEMP fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          ### TODO: test multiple platforms
+          # platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: ${{ github.repository == 'TosiDrop/vm-frontend' && 'tosidrop/vm-frontend' || github.repository }}
 
 jobs:
-  build-amd64:
+  build-images:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,18 +40,6 @@ jobs:
             type=semver,pattern={{version}}
             # tag the sha version unless we are a git tag
             type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/v') }},priority=300,format=long,prefix=
-      - id: meta-arch
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-            suffix=-amd64
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Semantic versioning from our tags
-            type=semver,pattern={{version}}
-            # tag the sha version unless we are a git tag
-            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/v') }},priority=300,format=long,prefix=
       - name: update version
         run: |
           echo "const version = \"${{ steps.meta.outputs.version }}\";" > client/src/version.ts
@@ -61,136 +49,13 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-arch.outputs.tags }}
           labels: ${{ steps.meta-arch.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      # TEMP fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      # TEMP fix
-      # Something strange is happening with the manifests when we push which
-      # breaks the downstream multi-arch-manifest, so pull and push to work
-      # around this by resubmitting manifests
-      - name: pull-and-push
-        run: |
-          for t in `echo '${{ steps.meta-arch.outputs.tags }}'`; do
-            docker pull $t && docker push $t
-          done
-
-  build-arm64:
-    runs-on: ["self-hosted", "ARM64"]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: qemu
-        uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - name: login
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Semantic versioning from our tags
-            type=semver,pattern={{version}}
-            # tag the sha version unless we are a git tag
-            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/v') }},priority=300,format=long,prefix=
-      - id: meta-arch
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-            suffix=-arm64v8
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Semantic versioning from our tags
-            type=semver,pattern={{version}}
-            # tag the sha version unless we are a git tag
-            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/v') }},priority=300,format=long,prefix=
-      - name: update version
-        run: |
-          echo "const version = \"${{ steps.meta.outputs.version }}\";" > client/src/version.ts
-          echo "export default version;" >> client/src/version.ts
-      - name: push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta-arch.outputs.tags }}
-          labels: ${{ steps.meta-arch.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      # TEMP fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      # TEMP fix
-      # Something strange is happening with the manifests when we push which
-      # breaks the downstream multi-arch-manifest, so pull and push to work
-      # around this by resubmitting manifests
-      - name: pull-and-push
-        run: |
-          for t in `echo '${{ steps.meta-arch.outputs.tags }}'`; do
-            docker pull $t && docker push $t
-          done
-
-  multi-arch-manifest:
-    runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm64]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Login
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Semantic versioning from our tags
-            type=semver,pattern={{version}}
-            # tag the sha version unless we are a git tag
-            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/v') }},priority=300,format=long,prefix=
-      - name: manifest
-        run: docker manifest create ${{ steps.meta.outputs.tags }} --amend ${{ steps.meta.outputs.tags }}-amd64 --amend ${{ steps.meta.outputs.tags }}-arm64v8
-      - name: manifest-master
-        run: docker manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master --amend ${{ steps.meta.outputs.tags }}-amd64 --amend ${{ steps.meta.outputs.tags }}-arm64v8
-        if: github.ref == 'refs/heads/master'
-      - name: push
-        run: docker manifest push ${{ steps.meta.outputs.tags }}
-      - name: push-master
-        run: docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:master
-        if: github.ref == 'refs/heads/master'
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [multi-arch-manifest]
+    needs: [build-images]
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       - uses: actions/github-script@v7


### PR DESCRIPTION
Since we no longer build the frontend in Docker, let's skip the split builds. We don't need it for just the Express backend.