### PR TITLE
feat(tx): attach CIP-20 "TosiDrop claim" metadata to claim transactions

### DIFF
--- a/client/src/components/Claim/SendAdaInfo/index.tsx
+++ b/client/src/components/Claim/SendAdaInfo/index.tsx
@@ -1,7 +1,7 @@
 import QRCode from "react-qr-code";
 import Copyable from "src/components/Copyable";
 import Spinner from "src/components/Spinner";
-import useTransfer from "src/hooks/cardano/useTransfer";
+import useClaim from "src/hooks/cardano/claim/useClaim";
 import { useWalletConnector } from "src/pages/Cardano/Claim/useWalletConnector";
 import { lovelaceToAda } from "src/utils";
 
@@ -24,7 +24,7 @@ const SendAdaInfo = ({
   setTransactionStatus,
 }: Params) => {
   const { wallet } = useWalletConnector();
-  const { transfer, loading: transferLoading } = useTransfer();
+  const { claim, loading: claimLoading } = useClaim();
 
   /**
    * render QR Code
@@ -45,7 +45,6 @@ const SendAdaInfo = ({
    */
   const renderSendAdaButton = () => {
     if (wallet) {
-      console.log("wallet", wallet);
       return (
         <div className="w-full flex justify-center">
           <button
@@ -53,7 +52,7 @@ const SendAdaInfo = ({
             onClick={sendADA}
           >
             Send ADA
-            {transferLoading ? (
+            {claimLoading ? (
               <div className="ml-2.5">
                 <Spinner></Spinner>
               </div>
@@ -68,13 +67,9 @@ const SendAdaInfo = ({
 
   const sendADA = async () => {
     if (txDetail == null) {
-      console.log("txDetail is null");
       throw new Error("Transaction not found");
     }
-    console.log("txDetail", txDetail);
-    console.log("txDetail.withdrawal_address", txDetail.withdrawal_address);
-    console.log("txDetail.deposit", txDetail.deposit);
-    await transfer(
+    await claim(
       {
         toAddress: txDetail.withdrawal_address,
         amountToSend: txDetail.deposit.toString(),

--- a/client/src/entities/dto.ts
+++ b/client/src/entities/dto.ts
@@ -55,6 +55,20 @@ export namespace Dto {
     };
   }
 
+  export interface CreateClaimTx extends Base {
+    body: {
+      fromAddress: string;
+      toAddress: string;
+      amountToSend: string;
+    };
+
+    response: {
+      witness: string;
+      txBody: string;
+      auxData?: string;
+    };
+  }
+
   export interface CreateDelegationTx extends Base {
     body: {
       poolId: string;
@@ -71,6 +85,7 @@ export namespace Dto {
     body: {
       signedWitness: string;
       txBody: string;
+      auxData?: string;
     };
 
     response: {

--- a/client/src/hooks/cardano/claim/useClaim.tsx
+++ b/client/src/hooks/cardano/claim/useClaim.tsx
@@ -1,23 +1,24 @@
 import { useState } from "react";
-import { createTransferTx, submitStakeTx } from "src/services/common";
-import useErrorHandler from "../useErrorHandler";
-import { useWalletConnector } from "src/pages/Cardano/Claim/useWalletConnector";
 import { useSelector } from "react-redux";
+import { useWalletConnector } from "src/pages/Cardano/Claim/useWalletConnector";
+import { createClaimTx, submitStakeTx } from "src/services/common";
+import { RootState } from "src/store";
+import useErrorHandler from "../../useErrorHandler";
 
-export default function useTransfer() {
+export default function useClaim() {
   const [loading, setLoading] = useState(false);
   const { handleError } = useErrorHandler();
   const { wallet } = useWalletConnector();
-  const { address } = useSelector((state: any) => state.wallet);
+  const { address } = useSelector((state: RootState) => state.wallet);
 
-  async function transfer(
+  async function claim(
     { toAddress, amountToSend }: { toAddress: string; amountToSend: string },
     callback?: (txId?: string) => void,
   ) {
     setLoading(true);
     try {
       if (!wallet) {
-        throw new Error("Please connect your wallet to transfer");
+        throw new Error("Please connect your wallet to claim");
       }
       if (!address) {
         throw new Error(
@@ -25,13 +26,13 @@ export default function useTransfer() {
         );
       }
 
-      const { witness, txBody } = await createTransferTx({
+      const { witness, txBody, auxData } = await createClaimTx({
         fromAddress: address,
         toAddress,
         amountToSend,
       });
       const signedWitness = await wallet.signTx(witness);
-      const { tx } = await submitStakeTx({ signedWitness, txBody });
+      const { tx } = await submitStakeTx({ signedWitness, txBody, auxData });
       const txId = await wallet.submitTx(tx);
       if (callback != null) {
         callback(txId);
@@ -44,7 +45,7 @@ export default function useTransfer() {
   }
 
   return {
-    transfer,
+    claim,
     loading,
   };
 }

--- a/client/src/services/common.ts
+++ b/client/src/services/common.ts
@@ -77,11 +77,11 @@ export async function createStakeTx(
   return response.data;
 }
 
-export async function createTransferTx(
-  params: Dto.CreateTransferTx["body"],
-): Promise<Dto.CreateTransferTx["response"]> {
-  const response = await axios.post<Dto.CreateTransferTx["response"]>(
-    `${API_URL}/api/tx/transfer`,
+export async function createClaimTx(
+  params: Dto.CreateClaimTx["body"],
+): Promise<Dto.CreateClaimTx["response"]> {
+  const response = await axios.post<Dto.CreateClaimTx["response"]>(
+    `${API_URL}/api/tx/claim`,
     params,
   );
   return response.data;

--- a/server/routes/tx.ts
+++ b/server/routes/tx.ts
@@ -31,18 +31,35 @@ router.post(
 router.post(
   "/submit",
   typedErrorHandlerWrapper<Dto.SubmitTx>(async function (req, res) {
-    const { signedWitness, txBody } = req.body;
-    const tx = await TxService.createTxToSubmit(signedWitness, txBody);
+    const { signedWitness, txBody, auxData } = req.body;
+    const tx = await TxService.createTxToSubmit(signedWitness, txBody, auxData);
     return res.status(200).send({
       tx,
     });
   })
 );
 
+function validateTransferParams(body: {
+  fromAddress?: string;
+  toAddress?: string;
+  amountToSend?: string;
+}) {
+  const { fromAddress, toAddress, amountToSend } = body;
+  if (!fromAddress || !toAddress || !amountToSend) {
+    throw createErrorWithCode(
+      HttpStatusCode.BAD_REQUEST,
+      "fromAddress, toAddress, and amountToSend are required"
+    );
+  }
+  return { fromAddress, toAddress, amountToSend };
+}
+
 router.post(
   "/transfer",
   typedErrorHandlerWrapper<Dto.CreateTransferTx>(async function (req, res) {
-    const { fromAddress, toAddress, amountToSend } = req.body;
+    const { fromAddress, toAddress, amountToSend } = validateTransferParams(
+      req.body
+    );
     const { witness, txBody } = await TxService.createTransferTx({
       fromAddress,
       toAddress,
@@ -51,6 +68,25 @@ router.post(
     return res.status(200).send({
       witness,
       txBody,
+    });
+  })
+);
+
+router.post(
+  "/claim",
+  typedErrorHandlerWrapper<Dto.CreateClaimTx>(async function (req, res) {
+    const { fromAddress, toAddress, amountToSend } = validateTransferParams(
+      req.body
+    );
+    const { witness, txBody, auxData } = await TxService.createClaimTx({
+      fromAddress,
+      toAddress,
+      amountToSend,
+    });
+    return res.status(200).send({
+      witness,
+      txBody,
+      auxData,
     });
   })
 );

--- a/server/service/tx.ts
+++ b/server/service/tx.ts
@@ -1,5 +1,6 @@
 import {
   Address,
+  AuxiliaryData,
   BigNum,
   Certificate,
   Certificates,
@@ -29,6 +30,9 @@ enum PaymentCredential {
   PaymentKeyHash = 0,
   PaymentScriptHash = 1,
 }
+
+const CIP20_METADATUM_LABEL = "674";
+const TOSIDROP_CLAIM_MESSAGE = "TosiDrop claim";
 
 export namespace TxService {
   export async function createDelegationTx(
@@ -85,22 +89,45 @@ export namespace TxService {
     };
   }
 
-  export async function createTxToSubmit(witness: string, txBody: string) {
+  export async function createTxToSubmit(
+    witness: string,
+    txBody: string,
+    auxData?: string
+  ) {
     const tx = Transaction.new(
       TransactionBody.from_hex(txBody),
-      TransactionWitnessSet.from_hex(witness)
+      TransactionWitnessSet.from_hex(witness),
+      auxData ? AuxiliaryData.from_hex(auxData) : undefined
     );
     return tx.to_hex();
   }
 
-  export async function createTransferTx({
+  export async function createTransferTx(params: {
+    fromAddress: string;
+    toAddress: string;
+    amountToSend: string;
+  }) {
+    return buildTransferBase({ ...params, attachClaimMetadata: false });
+  }
+
+  export async function createClaimTx(params: {
+    fromAddress: string;
+    toAddress: string;
+    amountToSend: string;
+  }) {
+    return buildTransferBase({ ...params, attachClaimMetadata: true });
+  }
+
+  async function buildTransferBase({
     fromAddress,
     toAddress,
     amountToSend,
+    attachClaimMetadata,
   }: {
     fromAddress: string;
     toAddress: string;
     amountToSend: string;
+    attachClaimMetadata: boolean;
   }) {
     const txBuilder = await createTxBuilder();
 
@@ -112,17 +139,32 @@ export namespace TxService {
         .build()
     );
 
+    if (attachClaimMetadata) {
+      txBuilder.add_json_metadatum(
+        BigNum.from_str(CIP20_METADATUM_LABEL),
+        JSON.stringify({ msg: [TOSIDROP_CLAIM_MESSAGE] })
+      );
+    }
+
     const availableUtxos = await getAvailableUtxos(fromAddress);
     txBuilder.add_inputs_from(availableUtxos, 0);
 
     txBuilder.add_change_if_needed(Address.from_bech32(fromAddress));
 
-    const txBody = txBuilder.build();
-    const transaction = Transaction.new(txBody, TransactionWitnessSet.new());
+    const fullTx = txBuilder.build_tx();
+    const txBody = fullTx.body();
+    const auxiliaryData = fullTx.auxiliary_data();
+
+    const unsignedTx = Transaction.new(
+      txBody,
+      TransactionWitnessSet.new(),
+      auxiliaryData
+    );
 
     return {
-      witness: transaction.to_hex(),
+      witness: unsignedTx.to_hex(),
       txBody: txBody.to_hex(),
+      auxData: auxiliaryData ? auxiliaryData.to_hex() : undefined,
     };
   }
 


### PR DESCRIPTION
Add a dedicated createClaimTx builder alongside createTransferTx that attaches CIP-20 transaction-message metadata (label 674, msg "TosiDrop claim") so claim deposits are identifiable on-chain. The client switches SendAdaInfo from useTransfer to a new useClaim hook; auxiliary data is threaded through /api/tx/claim and /api/tx/submit so the metadata survives signing and submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added claim transaction functionality for improved transaction handling
  * Introduced support for auxiliary data in transactions to enable enhanced metadata capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->