### PR TITLE
Potential fix for code scanning alert no. 8: Permissive CORS configuration

### DIFF
--- a/charts/vm-frontend/values.yaml
+++ b/charts/vm-frontend/values.yaml
@@ -35,7 +35,6 @@ environment:
   KOIOS_URL: https://koios.tosidrop.me/api/v1
   LOG_TYPE: combined
   PORT: 3000
-  CORS_ALLOWED_ORIGINS: https://tosidrop.me
   # TOSIFEE
   # TOSIFEE_WHITELIST
   # VM_API_TOKEN

--- a/charts/vm-frontend/values.yaml
+++ b/charts/vm-frontend/values.yaml
@@ -35,6 +35,7 @@ environment:
   KOIOS_URL: https://koios.tosidrop.me/api/v1
   LOG_TYPE: combined
   PORT: 3000
+  CORS_ALLOWED_ORIGINS: https://tosidrop.me
   # TOSIFEE
   # TOSIFEE_WHITELIST
   # VM_API_TOKEN

--- a/server/index.ts
+++ b/server/index.ts
@@ -61,6 +61,12 @@ const ALLOWED_CORS_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || "")
   .map((origin) => origin.trim())
   .filter((origin) => origin.length > 0);
 
+if (ALLOWED_CORS_ORIGINS.length === 0) {
+  console.warn(
+    "Warning: CORS_ALLOWED_ORIGINS is not set or empty. All browser cross-origin requests will be blocked.",
+  );
+}
+
 app.use(express.json());
 app.use(require("morgan")(LOG_TYPE));
 app.use(

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,7 +63,7 @@ const ALLOWED_CORS_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || "")
 
 if (ALLOWED_CORS_ORIGINS.length === 0) {
   console.warn(
-    "Warning: CORS_ALLOWED_ORIGINS is not set or empty. Cross-origin requests will not receive CORS headers and browser clients may fail.",
+    "Warning: CORS_ALLOWED_ORIGINS is not set or empty. Cross-origin requests will not receive CORS headers and will be blocked by browsers.",
   );
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,7 +63,7 @@ const ALLOWED_CORS_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || "")
 
 if (ALLOWED_CORS_ORIGINS.length === 0) {
   console.warn(
-    "Warning: CORS_ALLOWED_ORIGINS is not set or empty. All browser cross-origin requests will be blocked.",
+    "Warning: CORS_ALLOWED_ORIGINS is not set or empty. Cross-origin requests will not receive CORS headers and browser clients may fail.",
   );
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -56,9 +56,24 @@ const TOSIFEE = process.env.TOSIFEE || 1000000;
 const TOSIFEE_WHITELIST = process.env.TOSIFEE_WHITELIST;
 
 const app = express();
+const ALLOWED_CORS_ORIGINS = (process.env.CORS_ALLOWED_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
 app.use(express.json());
 app.use(require("morgan")(LOG_TYPE));
-app.use(cors({ origin: "*" }));
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+      return callback(
+        null,
+        ALLOWED_CORS_ORIGINS.includes(origin),
+      );
+    },
+  }),
+);
 
 app.use("/api/tx", TxRouter);
 app.use("/api/util", UtilRouter);


### PR DESCRIPTION
Potential fix for [https://github.com/TosiDrop/vm-frontend/security/code-scanning/8](https://github.com/TosiDrop/vm-frontend/security/code-scanning/8)

Use a restrictive allowlist for CORS origins instead of `"*"`. Best approach without breaking existing functionality is to read allowed origins from an environment variable and only allow requests from those origins; deny others. Also allow requests with no `Origin` header (non-browser/server-to-server tools).

In `server/index.ts`, replace the single permissive middleware line with:
- an allowlist derived from env (for deployment flexibility),
- a `cors` `origin` callback that validates the incoming origin against the allowlist and rejects non-allowlisted origins.

This keeps CORS enabled for intended frontends while removing broad access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented CORS origin allowlist. The server now restricts cross-origin requests to configured origins only, replacing the previous unrestricted access policy. Configuration required to specify allowed origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->